### PR TITLE
ci: pin profile-summary-cards action to v0.11.3 to fix failing runs

### DIFF
--- a/.github/workflows/profile-summary-cards.yml
+++ b/.github/workflows/profile-summary-cards.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: vn7n24fzkq/github-profile-summary-cards@release
+      - uses: vn7n24fzkq/github-profile-summary-cards@v0.11.3
         env:
           GITHUB_TOKEN: ${{ secrets.MY_TOKEN_SECRETS }}
         with:

--- a/.github/workflows/profile-summary-cards.yml
+++ b/.github/workflows/profile-summary-cards.yml
@@ -11,8 +11,8 @@ jobs:
     name: generate
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: vn7n24fzkq/github-profile-summary-cards@v0.11.3
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: vn7n24fzkq/github-profile-summary-cards@5a2e29efb909f77ce6628e633aaacde7a60eb6eb # v0.11.3
         env:
           GITHUB_TOKEN: ${{ secrets.MY_TOKEN_SECRETS }}
         with:


### PR DESCRIPTION
## 概要

7/18 のスケジュール実行から Profile Summary Cards が全カード失敗している（GraphQL `Resource limits for this query exceeded` + REST 403）。原因はトークンではなくアクション側の変更なので、`@release` を最後に成功したバージョン `v0.11.3` にピン留めする。

## なぜ変えるか

- 7/18 の初回失敗時、トークンは 7/17 成功時と同一（secret 更新は 7/19）。同じトークンで成功→失敗しており、認証の問題ではない。
- GraphQL が返すのは `Resource limits for this query exceeded`（コスト見積もり拒否）。未認証なら 401 になるはずで、これは**認証が通ったクエリだけ**が受け取るエラー。
- `@release` ブランチには 7/17 に `v0.11.4`〜`v0.11.6` + deploy が入っており、破綻タイミングと一致。アクション側で同種のエラー（resource-limit / 502-504 / rate limit）に対処中で、upstream issue [#306](https://github.com/vn7n24fzkq/github-profile-summary-cards/issues/306) が 7/18 に起票されている（未マージ）。

## どう変えたか

動く `@release` ブランチをやめ、最後に成功した実行（7/17 01:43）時点の状態に相当する `v0.11.3` にピン留め。回帰かどうかの切り分けも兼ねる。`v0.11.3` タグはアクションとして利用可能（`action.yml` + `dist/index.js` を確認済み）。

## テスト

マージ後に `workflow_dispatch` で手動実行し、カードが生成されるか検証する。復旧しない場合はアクション側でなく GitHub 側（アカウントのクエリコスト増）が原因と判断でき、upstream 修正待ちに切り替える。
